### PR TITLE
Fix reproducible issue by removing full path names in doxygen documentation.

### DIFF
--- a/doc/zipios.doxy.in
+++ b/doc/zipios.doxy.in
@@ -140,7 +140,7 @@ INLINE_INHERITED_MEMB  = YES
 # shortest path that makes the file name unique will be used
 # The default value is: YES.
 
-FULL_PATH_NAMES        = YES
+FULL_PATH_NAMES        = NO
 
 # The STRIP_FROM_PATH tag can be used to strip a user-defined part of the path.
 # Stripping is only done if one of the specified strings matches the left-hand


### PR DESCRIPTION
Hello,

The default full path name generated by doxygen breaks reproducible build in Debian.

This patch changes the doxygen FULL_PATH_NAMES option from YES to NO, to avoid variation in path names between two builds from different folders.

Thanks,

